### PR TITLE
Release/3.0.1

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,27 +1,24 @@
+# Multi-stage build to compile registry from source with latest Go
+FROM golang:1.23-alpine AS builder
+
+RUN apk add --no-cache git ca-certificates
+
+# Clone and build the registry from source with latest Go (fixes vulnerability)
+RUN set -eux; \
+    git clone --depth 1 --branch v3.0.0 https://github.com/distribution/distribution.git /src; \
+    cd /src; \
+    CGO_ENABLED=0 GOOS=linux go build -a -installsuffix cgo -o registry ./cmd/registry
+
+# Final stage - minimal runtime image
 FROM alpine:3.21
 
 RUN apk add --no-cache ca-certificates
 
-RUN set -eux; \
-# Check https://github.com/distribution/distribution/releases for latest version
-# Updated to use a newer version that should have Go vulnerability fixes
-    version='3.0.1'; \
-    apkArch="$(apk --print-arch)"; \
-    case "$apkArch" in \
-       x86_64)  arch='amd64';   sha256='UPDATE_HASH_HERE' ;; \
-       aarch64) arch='arm64';   sha256='UPDATE_HASH_HERE' ;; \
-       armhf)   arch='armv6';   sha256='UPDATE_HASH_HERE' ;; \
-       armv7)   arch='armv7';   sha256='UPDATE_HASH_HERE' ;; \
-       ppc64le) arch='ppc64le'; sha256='UPDATE_HASH_HERE' ;; \
-       s390x)   arch='s390x';   sha256='UPDATE_HASH_HERE' ;; \
-       riscv64) arch='riscv64'; sha256='UPDATE_HASH_HERE' ;; \
-       *) echo >&2 "error: unsupported architecture: $apkArch"; exit 1 ;; \
-    esac; \
-    wget -O registry.tar.gz "https://github.com/distribution/distribution/releases/download/v${version}/registry_${version}_linux_${arch}.tar.gz"; \
-    echo "$sha256 *registry.tar.gz" | sha256sum -c -; \
-    tar --extract --verbose --file registry.tar.gz --directory /bin/ registry; \
-    rm registry.tar.gz; \
-    registry --version
+# Copy the compiled binary from builder stage
+COPY --from=builder /src/registry /bin/registry
+
+# Verify the binary works
+RUN registry --version
 
 COPY ./config-example.yml /etc/distribution/config.yml
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -4,22 +4,20 @@ FROM golang:1.23-alpine AS builder
 RUN apk add --no-cache git ca-certificates
 
 # Clone and build the registry from source with latest Go (fixes vulnerability)
-RUN set -eux; \
-    git clone --depth 1 --branch v3.0.0 https://github.com/distribution/distribution.git /src; \
-    cd /src; \
-    CGO_ENABLED=0 GOOS=linux go build -a -installsuffix cgo -o registry ./cmd/registry
+WORKDIR /src
+RUN git clone --depth 1 --branch v3.0.0 https://github.com/distribution/distribution.git .
+RUN CGO_ENABLED=0 GOOS=linux go build -ldflags="-s -w" -o /registry ./cmd/registry
+
+# Test the binary works in builder
+RUN /registry --version
 
 # Final stage - minimal runtime image
 FROM alpine:3.21
 
 RUN apk add --no-cache ca-certificates
 
-# Copy the compiled binary from builder stage and make it executable
-COPY --from=builder /src/registry /bin/registry
-RUN chmod +x /bin/registry
-
-# Verify the binary works
-RUN registry --version
+# Copy the compiled binary from builder stage
+COPY --from=builder /registry /bin/registry
 
 COPY ./config-example.yml /etc/distribution/config.yml
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -14,8 +14,9 @@ FROM alpine:3.21
 
 RUN apk add --no-cache ca-certificates
 
-# Copy the compiled binary from builder stage
+# Copy the compiled binary from builder stage and make it executable
 COPY --from=builder /src/registry /bin/registry
+RUN chmod +x /bin/registry
 
 # Verify the binary works
 RUN registry --version


### PR DESCRIPTION
### **PR Type**
Enhancement


___

### **Description**
- Switch to multi-stage Docker build compiling from source

- Use latest Go version to address vulnerabilities

- Remove architecture-specific binary download logic

- Simplify and harden Dockerfile build process


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Dockerfile: Download prebuilt binaries"] -- "Remove" --> B["Dockerfile: Multi-stage build from source"]
  B -- "Compile with Go 1.23" --> C["Copy binary to runtime image"]
  C -- "Simplified, secure build" --> D["Final minimal image"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>Dockerfile</strong><dd><code>Refactor Dockerfile to build registry from source using Go 1.23</code></dd></summary>
<hr>

Dockerfile

<ul><li>Replace binary download with multi-stage build from source<br> <li> Use Go 1.23-alpine as builder for latest Go security<br> <li> Remove architecture and hash logic for prebuilt binaries<br> <li> Copy compiled binary into minimal Alpine runtime image</ul>


</details>


  </td>
  <td><a href="https://github.com/proteantecs/registry/pull/2/files#diff-dd2c0eb6ea5cfc6c4bd4eac30934e2d5746747af48fef6da689e85b752f39557">+17/-21</a>&nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

